### PR TITLE
Bump minio-py to 5.0.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ django>=2.1
 djangorestframework>=3.9
 humanfriendly>=4.18
 python-slugify>=1.2.6
-minio==5.0.1
+minio==5.0.6
 celery


### PR DESCRIPTION
Fix problem with endpoint parser on python 3.7.6 and latest version python 3.8