### PR TITLE
fix: removed RemovedInDjango40Warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v2.9.3] - 2021-03-07
+### Changed
+- Removed RemovedInDjango40Warning
+
 ## [v2.9.2] - 2020-09-03
 ### Changed
 - Set all fields in admin panel as read-only

--- a/apiqa_storage/admin.py
+++ b/apiqa_storage/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.urls import reverse, NoReverseMatch
 from django.utils.html import format_html
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _t
 
 from .models import Attachment
 
@@ -29,7 +29,7 @@ class AttachmentAdmin(admin.ModelAdmin):
             return format_html(f'<a href="{url}">{obj.name}</a>')
         except NoReverseMatch:
             return format_html(obj.name)
-    _name.short_description = _('Имя')
+    _name.short_description = _t('Имя')
     _name.admin_order_field = 'name'
 
     def get_queryset(self, request):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with codec_open(path.join(HERE_PATH, 'requirements.dev.txt'),
 
 setup(
     name='apiqa-storage',
-    version='2.9.2',
+    version='2.9.3',
     description='Apiqa user storage backend for django projects',
     # https://packaging.python.org/specifications/core-metadata/#description-optional
     long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
removed `RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy()._name.short_description = _('Имя')` warning